### PR TITLE
Undeprecate resolve service

### DIFF
--- a/lib/src/androidMain/kotlin/com/appstractive/dnssd/Discovery.android.kt
+++ b/lib/src/androidMain/kotlin/com/appstractive/dnssd/Discovery.android.kt
@@ -12,99 +12,100 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 actual fun discoverServices(type: String): Flow<DiscoveryEvent> = callbackFlow {
-  val multicastLock: WifiManager.MulticastLock by lazy {
-    if (multicastPermissionGranted()) {
-      wifiManager.createMulticastLock("nsdMulticastLock").also { it.setReferenceCounted(true) }
-    } else {
-      throw RuntimeException("Missing required permission CHANGE_WIFI_MULTICAST_STATE")
+    val multicastLock: WifiManager.MulticastLock by lazy {
+        if (multicastPermissionGranted()) {
+            wifiManager.createMulticastLock("nsdMulticastLock")
+                .also { it.setReferenceCounted(true) }
+        } else {
+            throw RuntimeException("Missing required permission CHANGE_WIFI_MULTICAST_STATE")
+        }
     }
-  }
-  val resolveSemaphore = Semaphore(1)
+    val resolveSemaphore = Semaphore(1)
 
-  multicastLock.acquire()
+    multicastLock.acquire()
 
-  fun resolveService(serviceInfo: NsdServiceInfo) {
-    thread {
-      resolveSemaphore.acquire()
-      nsdManager.resolveService(
-          serviceInfo,
-          object : NsdManager.ResolveListener {
-            override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-              println("onResolveFailed: $errorCode")
-              resolveSemaphore.release()
-            }
-
-            override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
-              resolveSemaphore.release()
-
-              val service: DiscoveredService =
-                  when {
-                    VERSION.SDK_INT >= VERSION_CODES.M -> serviceInfo.toCommon()
-                    else -> {
-                      val resolvedData =
-                          MDNSDiscover.resolve(
-                              "${serviceInfo.serviceName}${serviceInfo.serviceType}.local",
-                              5000,
-                          )
-
-                      val txtRecords = resolvedData?.txt?.dict?.toByteMap()
-
-                      serviceInfo.toCommon(txtRecords)
+    fun resolveService(serviceInfo: NsdServiceInfo) {
+        thread {
+            resolveSemaphore.acquire()
+            nsdManager.resolveService(
+                serviceInfo,
+                object : NsdManager.ResolveListener {
+                    override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                        println("onResolveFailed: $errorCode")
+                        resolveSemaphore.release()
                     }
-                  }
 
-              trySend(
-                  DiscoveryEvent.Resolved(
-                      service = service,
-                  ) {
-                    resolveService(serviceInfo)
-                  },
-              )
-            }
-          },
-      )
+                    override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
+                        resolveSemaphore.release()
+
+                        val service: DiscoveredService =
+                            when {
+                                VERSION.SDK_INT >= VERSION_CODES.M -> serviceInfo.toCommon()
+                                else -> {
+                                    val resolvedData =
+                                        MDNSDiscover.resolve(
+                                            "${serviceInfo.serviceName}${serviceInfo.serviceType}.local",
+                                            5000,
+                                        )
+
+                                    val txtRecords = resolvedData?.txt?.dict?.toByteMap()
+
+                                    serviceInfo.toCommon(txtRecords)
+                                }
+                            }
+
+                        trySend(
+                            DiscoveryEvent.Resolved(
+                                service = service,
+                            ) {
+                                resolveService(serviceInfo)
+                            },
+                        )
+                    }
+                },
+            )
+        }
     }
-  }
 
-  val listener: NsdManager.DiscoveryListener =
-      object : NsdManager.DiscoveryListener {
-        override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
-          println("onStartDiscoveryFailed($serviceType, $errorCode)")
+    val listener: NsdManager.DiscoveryListener =
+        object : NsdManager.DiscoveryListener {
+            override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+                println("onStartDiscoveryFailed($serviceType, $errorCode)")
+            }
+
+            override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+                println("onStopDiscoveryFailed($serviceType, $errorCode)")
+            }
+
+            override fun onDiscoveryStarted(serviceType: String) {}
+
+            override fun onDiscoveryStopped(serviceType: String) {}
+
+            override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+                trySend(
+                    DiscoveryEvent.Discovered(
+                        service = serviceInfo.toCommon(),
+                    ) {
+                        resolveService(serviceInfo)
+                    },
+                )
+            }
+
+            override fun onServiceLost(serviceInfo: NsdServiceInfo) {
+                trySend(
+                    DiscoveryEvent.Removed(
+                        service = serviceInfo.toCommon(),
+                    ),
+                )
+            }
         }
 
-        override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
-          println("onStopDiscoveryFailed($serviceType, $errorCode)")
-        }
+    nsdManager.discoverServices(type, NsdManager.PROTOCOL_DNS_SD, listener)
 
-        override fun onDiscoveryStarted(serviceType: String) {}
-
-        override fun onDiscoveryStopped(serviceType: String) {}
-
-        override fun onServiceFound(serviceInfo: NsdServiceInfo) {
-          trySend(
-              DiscoveryEvent.Discovered(
-                  service = serviceInfo.toCommon(),
-              ) {
-                resolveService(serviceInfo)
-              },
-          )
-        }
-
-        override fun onServiceLost(serviceInfo: NsdServiceInfo) {
-          trySend(
-              DiscoveryEvent.Removed(
-                  service = serviceInfo.toCommon(),
-              ),
-          )
-        }
-      }
-
-  nsdManager.discoverServices(type, NsdManager.PROTOCOL_DNS_SD, listener)
-
-  awaitClose {
-    multicastLock.release()
-    nsdManager.stopServiceDiscovery(listener)
-  }
+    awaitClose {
+        multicastLock.release()
+        nsdManager.stopServiceDiscovery(listener)
+    }
 }
 
 internal fun NsdServiceInfo.toCommon(txt: Map<String, ByteArray?>? = null): DiscoveredService =
@@ -118,19 +119,19 @@ internal fun NsdServiceInfo.toCommon(txt: Map<String, ByteArray?>? = null): Disc
     )
 
 private fun NsdServiceInfo.getAddresses(): List<String> {
-  if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
-    return hostAddresses.mapNotNull { it.hostAddress }
-  }
+    if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return hostAddresses.mapNotNull { it.hostAddress }
+    }
 
-  return host?.hostAddress?.let { listOf(it) } ?: emptyList()
+    return host?.hostAddress?.let { listOf(it) } ?: emptyList()
 }
 
 private fun NsdServiceInfo.getHostName(): String? {
-  if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
-    return hostAddresses.firstOrNull()?.canonicalHostName
-  }
+    if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return hostAddresses.firstOrNull()?.canonicalHostName
+    }
 
-  return host?.canonicalHostName
+    return host?.canonicalHostName
 }
 
 fun Map<String?, String?>.toByteMap(): Map<String, ByteArray?> =


### PR DESCRIPTION
Because nsdManager.resolveService is deprecated the new approach is used, via registerServiceInfoCallback (see https://developer.android.com/sdk/api_diff/34/changes) like on line 58. The Content of onServiceResolved is extracted to `onResolved()` so its logic will be used on both, the new and the old approach.